### PR TITLE
bump versions, remove sbt-dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -26,14 +26,14 @@ developers := List(
   )
 )
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.13.6"
 
-crossScalaVersions := List("2.10.7", "2.11.12", "2.12.13", "2.13.5", "3.0.0")
+crossScalaVersions := List("2.10.7", "2.11.12", "2.12.14", "2.13.6", "3.0.1")
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest-core" % "3.2.9",
-  "org.testng" % "testng" % "6.7", 
-  "commons-io" % "commons-io" % "1.3.2" % "test", 
+  "org.testng" % "testng" % "6.7",
+  "commons-io" % "commons-io" % "1.3.2" % "test",
   "org.scalatest" %% "scalatest-funsuite" % "3.2.9" % "test"
 )
 
@@ -104,9 +104,6 @@ pomExtra := (
     </developerConnection>
   </scm>
 )
-
-// Temporary disable publishing of doc in dotty, can't get it to build.
-publishArtifact in (Compile, packageDoc) := !scalaBinaryVersion.value.startsWith("3")
 
 def docTask(docDir: File, resDir: File, projectName: String): File = {
   val docLibDir = docDir / "lib"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-osgi" % "0.9.6")
-
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
(not sure if I'm submitting this to the right branch)

this came up at https://github.com/scala/community-build/pull/1472 , where I'm finding that leaving sbt-dotty around is problematic for dbuild. if you're on current sbt, sbt-dotty isn't needed anymore