### PR TITLE
TestNG 7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@ ScalaTest + TestNG provides integration support between ScalaTest and TestNG.
 
 **Usage**
 
-To use it for ScalaTest 3.2.9 and TestNG 6.7.x: 
+To use it for ScalaTest 3.2.11 and TestNG 6.7.x: 
 
 SBT: 
 
 ```
-libraryDependencies += "org.scalatestplus" %% "testng-6-7" % "3.2.9.0" % "test"
+libraryDependencies += "org.scalatestplus" %% "testng-6-7" % "3.2.11.0" % "test"
 ```
 
 Maven: 
@@ -17,7 +17,7 @@ Maven:
 <dependency>
   <groupId>org.scalatestplus</groupId>
   <artifactId>testng-6-7_2.13</artifactId>
-  <version>3.2.9.0</version>
+  <version>3.2.11.0</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 import java.io.PrintWriter
 import scala.io.Source
 
-name := "testng-6.7"
+name := "testng-7.5"
 
 organization := "org.scalatestplus"
 
-version := "3.2.10.0"
+version := "3.2.11.0"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-testng"))
 
@@ -31,10 +31,10 @@ scalaVersion := "2.13.6"
 crossScalaVersions := List("2.10.7", "2.11.12", "2.12.15", "2.13.6", "3.0.2")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest-core" % "3.2.10",
-  "org.testng" % "testng" % "6.7",
+  "org.scalatest" %% "scalatest-core" % "3.2.11",
+  "org.testng" % "testng" % "7.5",
   "commons-io" % "commons-io" % "1.3.2" % "test",
-  "org.scalatest" %% "scalatest-funsuite" % "3.2.10" % "test"
+  "org.scalatest" %% "scalatest-funsuite" % "3.2.11" % "test"
 )
 
 Compile / packageDoc / publishArtifact := !scalaBinaryVersion.value.startsWith("3")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.5
+sbt.version=1.5.8

--- a/src/main/scala/org/scalatestplus/testng/SingleTestAnnotationTransformer.scala
+++ b/src/main/scala/org/scalatestplus/testng/SingleTestAnnotationTransformer.scala
@@ -25,7 +25,7 @@ import java.lang.reflect.Constructor
 // Probably might work as private[testng], but not sure and right before the release.
 private[testng] class SingleTestAnnotationTransformer(testName: String) extends IAnnotationTransformer {
   override def transform( annotation: ITestAnnotation, testClass: java.lang.Class[_], testConstructor: Constructor[_], testMethod: Method): Unit = {
-    if (testName == testMethod.getName) 
+    if (testName != testMethod.getName) 
       annotation.setGroups(Array("org.scalatestplus.testng.singlemethodrun.methodname"))
   }
 }

--- a/src/test/scala/org/scalatestplus/testng/TestNGSuiteSuite.scala
+++ b/src/test/scala/org/scalatestplus/testng/TestNGSuiteSuite.scala
@@ -19,7 +19,6 @@ package org.scalatestplus.testng {
 import org.scalatest.events._
 import org.scalatestplus.testng.testpackage._
 import org.scalatest.fixture
-import org.hamcrest.core.IsAnything
 import org.scalatestplus.testng.SharedHelpers.EventRecordingReporter
 
   class TestNGSuiteSuite extends funsuite.AnyFunSuite {
@@ -83,9 +82,9 @@ import org.scalatestplus.testng.SharedHelpers.EventRecordingReporter
       status.setCompleted()
 
       assert(reporter.suiteStartingEventsReceived.isEmpty)
-      assert(reporter.testStartingEventsReceived.length == 1)
+      assert(reporter.testStartingEventsReceived.length == 2)
       assert(reporter.testFailedEventsReceived.length == 1)
-      assert(reporter.testIgnoredEventsReceived.length == 1)
+      assert(reporter.testCanceledEventsReceived.length == 1)
       assert(reporter.suiteCompletedEventsReceived.isEmpty)
     }
     


### PR DESCRIPTION
Updated code to work with TestNG 7.5, one significant change is the TestNG's skipped test is now mapped to TestCanceled, TestNG 7.5 now also calls onTestStart for skipped tests, so it maps correctly to our TestCanceled now.  We also no longer use reflection to set our SingleTestAnnotationTransformer as we now builds target to specific TestNG version.