### PR TITLE
TestCanceled to include Formatter

### DIFF
--- a/src/main/scala/org/scalatestplus/testng/TestNGSuiteLike.scala
+++ b/src/main/scala/org/scalatestplus/testng/TestNGSuiteLike.scala
@@ -338,7 +338,7 @@ trait TestNGSuiteLike extends Suite { thisSuite =>
       val testName = result.getName + params(result)
       val formatter = getIndentedTextForTest(testName, 1, true)
       val causedBy = result.getSkipCausedBy().asScala.map(_.getMethodName())
-      report(TestCanceled(tracker.nextOrdinal(), "Skipped caused by ", thisSuite.suiteName, thisSuite.getClass.getName, Some(thisSuite.getClass.getName), testName, testName, Vector.empty))
+      report(TestCanceled(tracker.nextOrdinal(), "Skipped caused by " + causedBy, thisSuite.suiteName, thisSuite.getClass.getName, Some(thisSuite.getClass.getName), testName, testName, Vector.empty, None, None, Some(formatter)))
     }
 
     /**

--- a/src/test/scala/org/scalatestplus/testng/TestNGSuiteSuite.scala
+++ b/src/test/scala/org/scalatestplus/testng/TestNGSuiteSuite.scala
@@ -85,6 +85,7 @@ import org.scalatestplus.testng.SharedHelpers.EventRecordingReporter
       assert(reporter.testStartingEventsReceived.length == 2)
       assert(reporter.testFailedEventsReceived.length == 1)
       assert(reporter.testCanceledEventsReceived.length == 1)
+      assert(reporter.testCanceledEventsReceived(0).formatter == Some(IndentedText("- depender", "depender", 1)))
       assert(reporter.suiteCompletedEventsReceived.isEmpty)
     }
     


### PR DESCRIPTION
TestCanceled fired from onTestSkipped should include the created formatter.