### PR TITLE
Changes for 3.3.0.0-alpha.1 for TestNG 7.5 (JDK8 support)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ name := "testng-7.5"
 
 organization := "org.scalatestplus"
 
-version := "3.2.17.0"
+version := "3.3.0.0-alpha.1"
 
 homepage := Some(url("https://github.com/scalatest/scalatestplus-testng"))
 
@@ -26,15 +26,15 @@ developers := List(
   )
 )
 
-scalaVersion := "2.13.11"
+scalaVersion := "2.13.12"
 
-crossScalaVersions := List("2.10.7", "2.11.12", "2.12.17", "2.13.11", "3.1.3")
+crossScalaVersions := List("2.11.12", "2.12.18", "2.13.12", "3.3.1")
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest-core" % "3.2.17",
+  "org.scalatest" %% "scalatest-core" % "3.3.0-alpha.1",
   "org.testng" % "testng" % "7.5",
   "commons-io" % "commons-io" % "1.3.2" % "test",
-  "org.scalatest" %% "scalatest-funsuite" % "3.2.17" % "test"
+  "org.scalatest" %% "scalatest-funsuite" % "3.3.0-alpha.1" % "test"
 )
 
 Compile / packageDoc / publishArtifact := !scalaBinaryVersion.value.startsWith("3")

--- a/src/main/scala/org/scalatestplus/testng/TestNGSuiteLike.scala
+++ b/src/main/scala/org/scalatestplus/testng/TestNGSuiteLike.scala
@@ -464,9 +464,4 @@ trait TestNGSuiteLike extends Suite { thisSuite =>
   override protected final def runTest(testName: String, args: Args): Status = {
     throw new UnsupportedOperationException
   }
-
-  /**
-   * Suite style name.
-   */
-  final override val styleName: String = "TestNGSuite"
 }


### PR DESCRIPTION
Made the source code to build with scalatest 3.3.0-alpha.1 and testng 7.5 (for JDK 8).